### PR TITLE
feat: improve startup by using a smaller container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,19 @@ version: '3'
 services:
   postgres:
     container_name: postgres
-    image: postgres
+    image: postgres:alpine
     restart: always
     env_file:
       - .env
     ports:
       - '5432:5432'
+    volumes:
+      - postgres:/var/lib/postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
 
   pgadmin:
     container_name: pgadmin
@@ -18,3 +25,9 @@ services:
       - .env
     ports:
       - '5050:80'
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres:


### PR DESCRIPTION
Also, add a healthcheck condition so pgadmin won't complain if postgres isn't up and running yet (found this pattern very useful for fast starting software such as hasura).